### PR TITLE
[BREAKING] Change config author field from an optional string to an object

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,13 +40,18 @@ mod deserializers {
 pub struct Config {
     pub(crate) name: String,
     pub(crate) description: String,
-    pub(crate) author: Option<String>,
+    pub(crate) author: Option<Author>,
     pub(crate) cover: Option<String>,
     #[serde(deserialize_with = "deserializers::locale")]
     pub(crate) locale: LocaleConfig,
     #[serde(deserialize_with = "deserializers::url")]
     pub(crate) url: Option<reqwest::Url>,
     pub(crate) twitter: TwitterConfig,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct Author {
+    pub(crate) name: String,
 }
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ impl Generator {
                             link rel="stylesheet" href="/katex/katex.min.css";
                             title { (title) }
                             @if let Some(author) = &self.config.author {
-                                meta name="author" content=(author);
+                                meta name="author" content=(author.name);
                             }
 
                             meta property="og:title" content=(title);
@@ -483,7 +483,7 @@ impl Generator {
                             link rel="stylesheet" href="/katex/katex.min.css";
                             title { (title) }
                             @if let Some(author) = &self.config.author {
-                                meta name="author" content=(author);
+                                meta name="author" content=(author.name);
                             }
 
                             meta property="og:title" content=(title);
@@ -581,7 +581,7 @@ impl Generator {
                                 meta name="description" content=(description);
                             }
                             @if let Some(author) = &self.config.author {
-                                meta name="author" content=(author);
+                                meta name="author" content=(author.name);
                             }
 
                             meta property="og:title" content=(title);
@@ -734,7 +734,7 @@ impl Generator {
                     link rel="stylesheet" href="/katex/katex.min.css";
                     title { (self.config.name) }
                     @if let Some(author) = &self.config.author {
-                        meta name="author" content=(author);
+                        meta name="author" content=(author.name);
                     }
 
                     meta property="og:title" content=(self.config.name);
@@ -819,7 +819,7 @@ impl Generator {
                                 meta name="description" content=(description);
                             }
                             @if let Some(author) = &self.config.author {
-                                meta name="author" content=(author);
+                                meta name="author" content=(author.name);
                             }
 
                             meta property="og:title" content=(title);
@@ -912,7 +912,7 @@ impl Generator {
                     link rel="stylesheet" href="/katex/katex.min.css";
                     title { (title) }
                     @if let Some(author) = &self.config.author {
-                        meta name="author" content=(author);
+                        meta name="author" content=(author.name);
                     }
 
                     meta property="og:title" content=(title);
@@ -1026,7 +1026,7 @@ impl Generator {
                                 meta name="viewport" content="width=device-width, initial-scale=1";
                                 title { (title) }
                                 @if let Some(author) = &config_ref.author {
-                                    meta name="author" content=(author);
+                                    meta name="author" content=(author.name);
                                 }
 
                                 meta property="og:title" content=(title);


### PR DESCRIPTION
`author` field must now be an object with the property `name` if it exists, this is in preparation of adding new author-related fields, namely `url`. 

## Migration
If you don't have a config or do have one without an `author` this breaking change doesn't affect you.
If you do have one with an `author` you need to change the author field to an object with the field `name` and set that field to what your old `author` field was